### PR TITLE
Improve students list UI with expandable cards

### DIFF
--- a/app/components/dashboards/TutorDashboard.tsx
+++ b/app/components/dashboards/TutorDashboard.tsx
@@ -20,6 +20,7 @@ import {
   Send,
   CheckCircle,
   XCircle,
+  ChevronDown,
 } from "lucide-react"
 import {
   Table,
@@ -55,11 +56,27 @@ export default function TutorDashboard() {
     especialidad: user?.especialidad || "",
   })
 
-  const [messageForm, setMessageForm] = useState({
-    mensaje: "",
-  })
+  // Función para enviar mensajes a un estudiante específico
+  const sendMessageTo = (email: string, mensaje: string) => {
+    if (!mensaje.trim()) {
+      addToast({
+        type: "error",
+        title: "Campos requeridos",
+        description: "Escribe un mensaje para el estudiante.",
+      })
+      return false
+    }
 
-  const [selectedStudentForView, setSelectedStudentForView] = useState("")
+    createNotification(email, "MENSAJE_TUTOR", `Mensaje de tu tutor: ${mensaje}`)
+
+    addToast({
+      type: "success",
+      title: "Mensaje enviado",
+      description: "El mensaje ha sido enviado al estudiante.",
+    })
+
+    return true
+  }
 
   const tutorTutorias = tutorias.filter((t) => t.tutorEmail === user?.email)
   const assignedStudents = getAssignedStudents(user?.email || "")
@@ -186,34 +203,6 @@ export default function TutorDashboard() {
     }
   }
 
-  /**
-   * Envía un mensaje al estudiante actualmente seleccionado.
-   */
-  const handleSendMessage = (e: React.FormEvent) => {
-    e.preventDefault()
-    if (!selectedStudentForView || !messageForm.mensaje) {
-      addToast({
-        type: "error",
-        title: "Campos requeridos",
-        description: "Selecciona un estudiante y escribe un mensaje.",
-      })
-      return
-    }
-
-    createNotification(
-      selectedStudentForView,
-      "MENSAJE_TUTOR",
-      `Mensaje de tu tutor: ${messageForm.mensaje}`,
-    )
-
-    addToast({
-      type: "success",
-      title: "Mensaje enviado",
-      description: "El mensaje ha sido enviado al estudiante.",
-    })
-
-    setMessageForm({ mensaje: "" })
-  }
 
   /**
    * Descarga un archivo previamente subido por un estudiante.
@@ -355,182 +344,31 @@ export default function TutorDashboard() {
           <div className="space-y-6">
             <h2 className="text-2xl font-bold text-gray-900">Mis Estudiantes Asignados</h2>
 
-            <div className="grid md:grid-cols-3 gap-6">
-              <div className="bg-white rounded-lg shadow p-6">
-                <h3 className="text-lg font-medium text-gray-900 mb-4">Lista de Estudiantes</h3>
-                {assignedStudents.length === 0 ? (
-                  <p className="text-gray-500">No tienes estudiantes asignados.</p>
-                ) : (
-                  <div className="space-y-2">
-                    {assignedStudents.map((student) => (
-                      <div
-                        key={student.id}
-                        onClick={() => setSelectedStudentForView(student.email)}
-                        className={`p-2 border rounded cursor-pointer ${
-                          selectedStudentForView === student.email ? "bg-red-50" : "bg-white"
-                        }`}
-                      >
-                        <p className="font-medium text-gray-900">
-                          {student.nombres} {student.apellidos}
-                        </p>
-                        <p className="text-sm text-gray-600">{student.email}</p>
-                      </div>
-                    ))}
-                  </div>
-                )}
+            {assignedStudents.length === 0 ? (
+              <p className="text-gray-500">No tienes estudiantes asignados.</p>
+            ) : (
+              <div className="grid md:grid-cols-2 gap-6">
+                {assignedStudents.map((student) => {
+                  const studentTheme = getThemeByStudent(student.email)
+                  const studentTutorias = tutorTutorias.filter((t) => t.estudianteEmail === student.email)
+                  const studentArchivos = studentFiles.filter((f) => f.estudianteEmail === student.email)
+
+                  return (
+                    <StudentCard
+                      key={student.id}
+                      student={student}
+                      theme={studentTheme}
+                      tutorias={studentTutorias}
+                      archivos={studentArchivos}
+                      onTutoriaAction={handleTutoriaAction}
+                      onThemeAction={handleThemeAction}
+                      onDownloadFile={handleDownloadFile}
+                      onSendMessage={sendMessageTo}
+                    />
+                  )
+                })}
               </div>
-
-              <div className="md:col-span-2 space-y-6">
-                {selectedStudentForView ? (
-                  (() => {
-                    const student = assignedStudents.find((s) => s.email === selectedStudentForView)
-                    const studentTheme = getThemeByStudent(selectedStudentForView)
-                    const studentTutorias = tutorTutorias.filter((t) => t.estudianteEmail === selectedStudentForView)
-                    const studentArchivos = studentFiles.filter((f) => f.estudianteEmail === selectedStudentForView)
-
-                    return (
-                      <div className="bg-white rounded-lg shadow p-6 space-y-4">
-                        <div>
-                          <h3 className="text-lg font-medium text-gray-900 mb-2">Información del Estudiante</h3>
-                          <p>
-                            <strong>Nombre:</strong> {student?.nombres} {student?.apellidos}
-                          </p>
-                          <p>
-                            <strong>Email:</strong> {student?.email}
-                          </p>
-                          <p>
-                            <strong>Carrera:</strong> {student?.carrera}
-                          </p>
-                        </div>
-
-                        {studentTheme && (
-                          <div>
-                            <h4 className="font-medium text-gray-900 mb-2">Tema Propuesto</h4>
-                            <div className="p-3 bg-white rounded border">
-                              <p>
-                                <strong>Título:</strong> {studentTheme.titulo}
-                              </p>
-                              <p>
-                                <strong>Descripción:</strong> {studentTheme.descripcion}
-                              </p>
-                              <p>
-                                <strong>Estado:</strong>
-                                <span
-                                  className={`ml-2 px-2 py-1 rounded-full text-xs ${
-                                    studentTheme.aprobado
-                                      ? "bg-green-100 text-green-800"
-                                      : studentTheme.fechaRevision
-                                      ? "bg-red-100 text-red-800"
-                                      : "bg-yellow-100 text-yellow-800"
-                                  }`}
-                                >
-                                  {studentTheme.aprobado
-                                    ? "Aprobado"
-                                    : studentTheme.fechaRevision
-                                    ? "Rechazado"
-                                    : "Pendiente"}
-                                </span>
-                              </p>
-
-                              {!studentTheme.aprobado && !studentTheme.fechaRevision && (
-                                <div className="mt-2">
-                                  <ThemeActionButtons themeId={studentTheme.id} onAction={handleThemeAction} />
-                                </div>
-                              )}
-
-                              {studentTheme.observaciones && (
-                                <div className="mt-2 p-2 bg-blue-50 rounded">
-                                  <p className="text-sm text-blue-800">
-                                    <strong>Observaciones:</strong> {studentTheme.observaciones}
-                                  </p>
-                                </div>
-                              )}
-                            </div>
-                          </div>
-                        )}
-
-                        <div>
-                          <h4 className="font-medium text-gray-900 mb-2">Tutorías ({studentTutorias.length})</h4>
-                          {studentTutorias.length > 0 ? (
-                            <Table>
-                              <TableHeader>
-                                <TableRow>
-                                  <TableHead>Asunto</TableHead>
-                                  <TableHead>Fecha</TableHead>
-                                  <TableHead>Hora</TableHead>
-                                  <TableHead>Estado</TableHead>
-                                  <TableHead>Acciones</TableHead>
-                                </TableRow>
-                              </TableHeader>
-                              <TableBody>
-                                {studentTutorias.map((tutoria) => (
-                                  <TutoriaRow
-                                    key={tutoria.id}
-                                    tutoria={tutoria}
-                                    onAction={handleTutoriaAction}
-                                  />
-                                ))}
-                              </TableBody>
-                            </Table>
-                          ) : (
-                            <p className="text-gray-500 text-sm">No hay tutorías registradas</p>
-                          )}
-                        </div>
-
-                        <div>
-                          <h4 className="font-medium text-gray-900 mb-2">Archivos ({studentArchivos.length})</h4>
-                          {studentArchivos.length > 0 ? (
-                            <div className="space-y-2">
-                              {studentArchivos.slice(0, 3).map((archivo) => (
-                                <div
-                                  key={archivo.id}
-                                  className="p-2 bg-white rounded border text-sm flex justify-between items-center"
-                                >
-                                  <span>{archivo.nombre}</span>
-                                  <button
-                                    onClick={() => handleDownloadFile(archivo)}
-                                    className="text-blue-600 hover:text-blue-800 text-xs"
-                                  >
-                                    Descargar
-                                  </button>
-                                </div>
-                              ))}
-                            </div>
-                          ) : (
-                            <p className="text-gray-500 text-sm">No hay archivos subidos</p>
-                          )}
-                        </div>
-
-                        <form onSubmit={handleSendMessage} className="space-y-3 pt-4">
-                          <div>
-                            <label className="block text-sm font-medium text-gray-700 mb-2">Indicaciones para el estudiante</label>
-                            <textarea
-                              value={messageForm.mensaje}
-                              onChange={(e) => setMessageForm({ mensaje: e.target.value })}
-                              rows={3}
-                              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-red-500"
-                              placeholder="Escribe tus indicaciones aquí..."
-                              required
-                            />
-                          </div>
-                          <button
-                            type="submit"
-                            className="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 flex items-center gap-2"
-                          >
-                            <Send size={16} />
-                            Enviar Mensaje
-                          </button>
-                        </form>
-                      </div>
-                    )
-                  })()
-                ) : (
-                  <div className="bg-white rounded-lg shadow p-6 flex items-center justify-center h-full text-gray-500">
-                    Selecciona un estudiante para ver la información
-                  </div>
-                )}
-              </div>
-            </div>
+            )}
           </div>
         )
 
@@ -959,6 +797,184 @@ function ThemeActionButtons({
               Cancelar
             </button>
           </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// Tarjeta expandible para mostrar la información completa de un estudiante
+function StudentCard({
+  student,
+  theme,
+  tutorias,
+  archivos,
+  onTutoriaAction,
+  onThemeAction,
+  onDownloadFile,
+  onSendMessage,
+}: {
+  student: any
+  theme: any
+  tutorias: any[]
+  archivos: any[]
+  onTutoriaAction: (id: string, action: "aceptar" | "rechazar", observaciones?: string) => void
+  onThemeAction: (id: string, action: "aprobar" | "rechazar", observaciones?: string) => void
+  onDownloadFile: (archivo: any) => void
+  onSendMessage: (email: string, mensaje: string) => boolean
+}) {
+  const [open, setOpen] = useState(false)
+  const [mensaje, setMensaje] = useState("")
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (onSendMessage(student.email, mensaje)) {
+      setMensaje("")
+    }
+  }
+
+  return (
+    <div className="bg-white rounded-lg shadow">
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className="w-full p-4 flex justify-between items-center"
+      >
+        <div>
+          <p className="font-medium text-gray-900">
+            {student.nombres} {student.apellidos}
+          </p>
+          <p className="text-sm text-gray-600">{student.email}</p>
+        </div>
+        <ChevronDown
+          size={20}
+          className={`transition-transform ${open ? "rotate-180" : ""}`}
+        />
+      </button>
+
+      {open && (
+        <div className="p-4 border-t space-y-4">
+          <div>
+            <h4 className="font-medium text-gray-900 mb-2">Resumen</h4>
+            <p>
+              <strong>Carrera:</strong> {student.carrera}
+            </p>
+          </div>
+
+          {theme && (
+            <div>
+              <h4 className="font-medium text-gray-900 mb-2">Tema Propuesto</h4>
+              <div className="p-3 bg-white rounded border">
+                <p>
+                  <strong>Título:</strong> {theme.titulo}
+                </p>
+                <p>
+                  <strong>Descripción:</strong> {theme.descripcion}
+                </p>
+                <p>
+                  <strong>Estado:</strong>
+                  <span
+                    className={`ml-2 px-2 py-1 rounded-full text-xs ${
+                      theme.aprobado
+                        ? "bg-green-100 text-green-800"
+                        : theme.fechaRevision
+                        ? "bg-red-100 text-red-800"
+                        : "bg-yellow-100 text-yellow-800"
+                    }`}
+                  >
+                    {theme.aprobado
+                      ? "Aprobado"
+                      : theme.fechaRevision
+                      ? "Rechazado"
+                      : "Pendiente"}
+                  </span>
+                </p>
+
+                {!theme.aprobado && !theme.fechaRevision && (
+                  <div className="mt-2">
+                    <ThemeActionButtons themeId={theme.id} onAction={onThemeAction} />
+                  </div>
+                )}
+
+                {theme.observaciones && (
+                  <div className="mt-2 p-2 bg-blue-50 rounded">
+                    <p className="text-sm text-blue-800">
+                      <strong>Observaciones:</strong> {theme.observaciones}
+                    </p>
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+
+          <div>
+            <h4 className="font-medium text-gray-900 mb-2">Tutorías ({tutorias.length})</h4>
+            {tutorias.length > 0 ? (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Asunto</TableHead>
+                    <TableHead>Fecha</TableHead>
+                    <TableHead>Hora</TableHead>
+                    <TableHead>Estado</TableHead>
+                    <TableHead>Acciones</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {tutorias.map((tutoria) => (
+                    <TutoriaRow key={tutoria.id} tutoria={tutoria} onAction={onTutoriaAction} />
+                  ))}
+                </TableBody>
+              </Table>
+            ) : (
+              <p className="text-gray-500 text-sm">No hay tutorías registradas</p>
+            )}
+          </div>
+
+          <div>
+            <h4 className="font-medium text-gray-900 mb-2">Archivos ({archivos.length})</h4>
+            {archivos.length > 0 ? (
+              <div className="space-y-2">
+                {archivos.slice(0, 3).map((archivo) => (
+                  <div
+                    key={archivo.id}
+                    className="p-2 bg-white rounded border text-sm flex justify-between items-center"
+                  >
+                    <span>{archivo.nombre}</span>
+                    <button
+                      onClick={() => onDownloadFile(archivo)}
+                      className="text-blue-600 hover:text-blue-800 text-xs"
+                    >
+                      Descargar
+                    </button>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="text-gray-500 text-sm">No hay archivos subidos</p>
+            )}
+          </div>
+
+          <form onSubmit={handleSubmit} className="space-y-3 pt-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">Indicaciones para el estudiante</label>
+              <textarea
+                value={mensaje}
+                onChange={(e) => setMensaje(e.target.value)}
+                rows={3}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-red-500"
+                placeholder="Escribe tus indicaciones aquí..."
+                required
+              />
+            </div>
+            <button
+              type="submit"
+              className="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 flex items-center gap-2"
+            >
+              <Send size={16} />
+              Enviar Mensaje
+            </button>
+          </form>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- redesigned tutor dashboard student view with student cards
- added new `StudentCard` component to display summary, theme, tutorías and files
- messages are sent via new `sendMessageTo` function

## Testing
- `npm run lint` *(fails: prompts for configuration)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688953ed9b688328afafb75848c37df2