### PR TITLE
Hide theme actions after rejection

### DIFF
--- a/app/components/Modals/StudentDetailsModal.tsx
+++ b/app/components/Modals/StudentDetailsModal.tsx
@@ -167,7 +167,7 @@ export default function StudentDetailsModal({ student, onClose }: StudentDetails
                     {theme.aprobado ? 'Aprobado' : theme.fechaRevision ? 'Rechazado' : 'Pendiente'}
                   </span>
                 </p>
-                {!theme.aprobado && (
+                {!theme.aprobado && !theme.fechaRevision && (
                   <div className="mt-2">
                     <ThemeActionButtons themeId={theme.id} onAction={handleThemeAction} />
                   </div>

--- a/app/components/Panels/StudentDetailsPanel.tsx
+++ b/app/components/Panels/StudentDetailsPanel.tsx
@@ -234,7 +234,7 @@ export default function StudentDetailsPanel({ student, onClose }: StudentDetails
                     {theme.aprobado ? "Aprobado" : theme.fechaRevision ? "Rechazado" : "Pendiente"}
                   </span>
                 </p>
-                {!theme.aprobado && (
+                {!theme.aprobado && !theme.fechaRevision && (
                   <div className="mt-2">
                     <ThemeActionButtons themeId={theme.id} onAction={handleThemeAction} />
                   </div>

--- a/app/dashboard/estudiantes/[email]/page.tsx
+++ b/app/dashboard/estudiantes/[email]/page.tsx
@@ -218,7 +218,7 @@ export default function StudentDetailsPage({ params }: { params: { email: string
                   {theme.aprobado ? 'Aprobado' : theme.fechaRevision ? 'Rechazado' : 'Pendiente'}
                 </span>
               </p>
-              {!theme.aprobado && (
+              {!theme.aprobado && !theme.fechaRevision && (
                 <div className="mt-2">
                   <ThemeActionButtons themeId={theme.id} onAction={handleThemeAction} />
                 </div>


### PR DESCRIPTION
## Summary
- hide approve/reject options once a theme has been reviewed

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68898fc225b883289e4e294846434f2e